### PR TITLE
Fix: set_with_slop function returns 0 when successful

### DIFF
--- a/bashcaster.sh
+++ b/bashcaster.sh
@@ -100,6 +100,7 @@ function set_to_screen_dimensions {
 function set_with_slop {
     check_program slop || return 1
     read left top width height < <(slop -f '%x %y %w %h')
+    return 0
 }
 
 function set_rectangle {


### PR DESCRIPTION
Previously, with `slop` installed, when I did a rectangle selection with `-R`, `slop` would make me select a screen region, but afterwards the script would still prompt me for the fallback region-selection method.
This was because the function `set_with_slop` was still returning `1` (on my installation at least) for some reason.
With this commit `set_with_slop` will now return `0` when `slop` is available and was used.